### PR TITLE
Moved stateless function outside of MarketMaker class

### DIFF
--- a/src/market-maker-bot-backend/market_maker.mo
+++ b/src/market-maker-bot-backend/market_maker.mo
@@ -1,18 +1,9 @@
-/// A module which contain implementation of market maker class for one pair
-/// Contain implelemtation of manage orders for one iteration, should be called by
-/// "orchestrator" each time when we wanna put BID and ASK orders
-///
-/// Copyright: 2023-2024 MR Research AG
-/// Main author: Dmitriy Panchenko
-/// Contributors: Timo Hanke
-
 import Float "mo:base/Float";
 import Principal "mo:base/Principal";
 import Int "mo:base/Int";
 import Int64 "mo:base/Int64";
 import Nat32 "mo:base/Nat32";
 import Cycles "mo:base/ExperimentalCycles";
-import Nat "mo:base/Nat";
 import Debug "mo:base/Debug";
 import Oracle "./oracle";
 import Auction "./auction";
@@ -43,16 +34,16 @@ module MarketMakerModule {
     price : Float;
   };
 
-  public type Asset = {
+  public type AssetInfo = {
     principal : Principal;
-    symbol : Text;
+    asset : Oracle.Asset;
     decimals : Nat32;
   };
 
-  public type Pair = {
-    base : Asset;
-    quote : Asset;
-    spread_value: Float;
+  public type MarketPair = {
+    base : AssetInfo;
+    quote : AssetInfo;
+    spread_value : Float;
   };
 
   public type ExecutionError = {
@@ -66,110 +57,110 @@ module MarketMakerModule {
     #TooLowOrderError;
   };
 
-  public class MarketMaker(pair : Pair, xrc : Oracle.Self, ac : Auction.Self) {
-    func getCurrentRate(baseSymbol: Text, quoteSymbol: Text) : async* {
-      #Ok : CurrencyRate;
-      #Err : {
-        #ErrorGetRates;
-      }
-    } {
-      let request: Oracle.GetExchangeRateRequest = {
-        timestamp = null;
-        quote_asset = { class_ = #Cryptocurrency; symbol = quoteSymbol };
-        base_asset = { class_ = #Cryptocurrency; symbol = baseSymbol };
+  // Consider making a class Oracle which
+  // - takes xrc as constructor argument
+  // - provides function getCurrenrRate(base, quote)
+  // - is instantiated once in main.mo
+  // - is passed to the MarketMaker constructor in place of xrc : Oracle.Self
+  // So essentially a class that wraps around Oracle.Self
+  //
+  // As a side effect: This helps in testing MarketMaker with Motoko-only tests (with the interpreter, mops test)
+  // The test can mock the class without actually using Oracle.Self
+  func getCurrentRate(xrc : Oracle.Self, base : Oracle.Asset, quote : Oracle.Asset) : async* {
+    #Ok : CurrencyRate;
+    #Err : {
+      #ErrorGetRates;
+    };
+  } {
+    let request : Oracle.GetExchangeRateRequest = {
+      timestamp = null;
+      quote_asset = quote;
+      base_asset = base;
+    };
+    Cycles.add<system>(10_000_000_000);
+    let response = await xrc.get_exchange_rate(request);
+
+    switch (response) {
+      case (#Ok(success)) {
+        let currency_rate : CurrencyRate = {
+          rate = success.rate;
+          decimals = success.metadata.decimals;
+        };
+
+        return #Ok(currency_rate);
       };
-      Cycles.add<system>(10_000_000_000);
-      let response = await xrc.get_exchange_rate(request);
-
-      switch (response) {
-        case (#Ok(success)) {
-          let currency_rate : CurrencyRate = {
-            rate = success.rate;
-            decimals = success.metadata.decimals;
-          };
-
-          return #Ok(currency_rate);
-        };
-        case (#Err(_)) {
-          return #Err(#ErrorGetRates);
-        };
-      }
+      case (#Err(_)) {
+        return #Err(#ErrorGetRates);
+      };
     };
+  };
 
-    func getPrices(spread : Float, currency_rate : CurrencyRate) : PricesInfo {
-      let exponent : Float = Float.fromInt64(Int64.fromNat64(Nat32.toNat64(currency_rate.decimals)));
-      let float_price : Float = Float.fromInt64(Int64.fromNat64(currency_rate.rate)) / Float.pow(10, exponent);
+  // Consider making a class Auction which
+  // - takes ac as constructor argument
+  // - provides function replaceOrders
+  // - is instantiated once in main.mo
+  // - is passed to the MarketMaker constructor in place of ac : Auction.Self
+  // So essentially a class that wraps around Auction.Self
+  //
+  // As a side effect: This helps in testing MarketMaker with Motoko-only tests (with the interpreter, mops test)
+  // The test can mock the class without actually using Auction.Self
+  func replaceOrders(ac : Auction.Self, token : Principal, bid : OrderInfo, ask : OrderInfo) : async* {
+    #Ok : [Nat];
+    #Err : Auction.ManageOrdersError;
+  } {
+    let response = await ac.manageOrders(
+      ?(#all(?[token])), // cancell all orders for tokens
+      [#bid(token, bid.amount, bid.price), #ask(token, ask.amount, ask.price)],
+    );
 
-      {
-        bid_price = float_price * (1.0 - spread);
-        ask_price = float_price * (1.0 + spread);
-      }
-    };
+    switch (response) {
+      case (#Ok(success)) #Ok(success);
+      case (#Err(error)) {
+        switch (error) {
+          case (#cancellation(_)) {
+            let response = await ac.manageOrders(
+              ?(#orders([])),
+              [#bid(token, bid.amount, bid.price), #ask(token, ask.amount, ask.price)],
+            );
 
-    func calculateVolumeStep(price : Float) : Int {
-      let p = price / Float.fromInt(10 ** 3);
-      if (p >= 1) return 1;
-      let zf = - Float.log(p) / 2.302_585_092_994_045;
-      Int.abs(10 ** Float.toInt(zf));
-    };
-
-    func getVolumes(credits : CreditsInfo, prices : PricesInfo) : ValumesInfo {
-      let volume_step = calculateVolumeStep(prices.bid_price);
-      {
-        bid_volume = Int.abs((Float.toInt(Float.fromInt(credits.quote_credit) / prices.bid_price) / volume_step) * volume_step);
-        ask_volume = Int.abs((credits.base_credit / volume_step) * volume_step);
-      }
-    };
-
-    func replaceOrders(token: Principal, bid : OrderInfo, ask : OrderInfo) : async* {
-      #Ok : [Nat];
-      #Err : Auction.ManageOrdersError;
-    } {
-      let response = await ac.manageOrders(
-        ?(#all (?[token])), // cancell all orders for tokens
-        [#bid (token, bid.amount, bid.price), #ask (token, ask.amount, ask.price)],
-      );
-
-
-      switch (response) {
-        case (#Ok(success)) #Ok(success);
-        case (#Err(error)) {
-          switch (error) {
-            case (#cancellation(_)) {
-              let response = await ac.manageOrders(
-                ?(#orders ([])),
-                [#bid (token, bid.amount, bid.price), #ask (token, ask.amount, ask.price)],
-              );
-
-              switch (response) {
-                case (#Ok(success)) #Ok(success);
-                case (#Err(error)) #Err(error);
-              }
+            switch (response) {
+              case (#Ok(success)) #Ok(success);
+              case (#Err(error)) #Err(error);
             };
-            case (_) #Err(error);
-          }
+          };
+          case (_) #Err(error);
         };
-      }
+      };
     };
+  };
 
-    public func execute(credits: CreditsInfo) : async* {
-      #Ok: (OrderInfo, OrderInfo);
+  func getPrices(spread : Float, currency_rate : CurrencyRate) : PricesInfo {
+    let exponent : Float = Float.fromInt64(Int64.fromNat64(Nat32.toNat64(currency_rate.decimals)));
+    let float_price : Float = Float.fromInt64(Int64.fromNat64(currency_rate.rate)) / Float.pow(10, exponent);
+
+    {
+      bid_price = float_price * (1.0 - spread);
+      ask_price = float_price * (1.0 + spread);
+    };
+  };
+
+  func getVolumes(credits : CreditsInfo, prices : PricesInfo) : ValumesInfo {
+    {
+      bid_volume = Int.abs(Float.toInt(Float.fromInt(credits.quote_credit) / prices.bid_price));
+      ask_volume = credits.base_credit;
+    };
+  };
+
+
+  public class MarketMaker(pair : MarketPair, xrc : Oracle.Self, ac : Auction.Self) {
+
+    public func execute(credits : CreditsInfo) : async* {
+      #Ok : (OrderInfo, OrderInfo);
       #Err : ExecutionError;
     } {
       // let { base_credit; quote_credit } = await* queryCredits(pair.base.principal, pair.quote.principal);
-      var current_rate_result : {
-        #Ok : CurrencyRate;
-        #Err : {
-          #ErrorGetRates;
-        }
-      } = #Err(#ErrorGetRates);
       let { base_credit; quote_credit } = credits;
-      try {
-        current_rate_result := await* getCurrentRate(pair.base.symbol, pair.quote.symbol);
-      } catch (_) {
-        ignore await* removeOrders();
-        return #Err(#RatesError);
-      };
+      let current_rate_result = await* getCurrentRate(xrc, pair.base.asset, pair.quote.asset);
 
       switch (current_rate_result) {
         case (#Ok(current_rate)) {
@@ -185,12 +176,11 @@ module MarketMakerModule {
             price = ask_price;
           };
 
-          let replace_orders_result = await* replaceOrders(pair.base.principal, bid_order, ask_order);
+          let replace_orders_result = await* replaceOrders(ac, pair.base.principal, bid_order, ask_order);
 
           switch (replace_orders_result) {
             case (#Ok(_)) #Ok(bid_order, ask_order);
             case (#Err(err)) {
-              ignore await* removeOrders();
               switch (err) {
                 case (#placement(err)) {
                   switch (err.error) {
@@ -198,21 +188,20 @@ module MarketMakerModule {
                     case (#UnknownAsset) #Err(#UnknownAssetError);
                     case (#NoCredit) #Err(#NoCreditError);
                     case (#TooLowOrder) #Err(#TooLowOrderError);
-                  }
+                  };
                 };
                 case (#cancellation(err)) #Err(#CancellationError);
                 case (#UnknownPrincipal) #Err(#UnknownPrincipal);
-              }
+              };
             };
-          }
+          };
         };
         case (#Err(err)) {
-          ignore await* removeOrders();
           switch (err) {
             case (#ErrorGetRates) #Err(#RatesError);
-          }
+          };
         };
-      }
+      };
     };
 
     public func removeOrders() : async* {
@@ -221,23 +210,19 @@ module MarketMakerModule {
         #CancellationError;
       };
     } {
-      try {
-        let response = await ac.manageOrders(
-          ?(#all (?[pair.base.principal])), // cancell all orders for tokens
-          [],
-        );
+      let response = await ac.manageOrders(
+        ?(#all(?[pair.base.principal])), // cancell all orders for tokens
+        [],
+      );
 
-        switch (response) {
-          case (#Ok(_)) #Ok;
-          case (#Err(_)) #Err(#CancellationError);
-        }
-      } catch (_) {
-        return #Err(#CancellationError);
-      }
+      switch (response) {
+        case (#Ok(_)) #Ok;
+        case (#Err(_)) #Err(#CancellationError);
+      };
     };
 
-    public func getPair() : (Pair) {
+    public func getPair() : (MarketPair) {
       pair;
-    }
-  }
-}
+    };
+  };
+};


### PR DESCRIPTION
Moved all functions that don't depend on `pair` to the top-level of the module, outside of the class.

In the comments, suggested a further abstraction of Auction and Oracle.